### PR TITLE
updated the variable for ingress rules

### DIFF
--- a/example/variables.tf
+++ b/example/variables.tf
@@ -28,6 +28,7 @@ variable "kms_alias_name" {
 variable "additional_ingress_rules_aurora" {
   description = "Additional ingress rules for Aurora"
   type = list(object({
+    name        = string
     description = string
     type        = string
     from_port   = number
@@ -41,6 +42,7 @@ variable "additional_ingress_rules_aurora" {
 variable "additional_ingress_rules_rds" {
   description = "Additional ingress rules for RDS"
   type = list(object({
+    name        = string
     description = string
     type        = string
     from_port   = number

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,7 @@ variable "aurora_serverlessv2_scaling_configuration" {
 variable "additional_ingress_rules_aurora" {
   description = "Additional ingress rules for Aurora"
   type = list(object({
+    name        = string
     description = string
     type        = string
     from_port   = number
@@ -538,6 +539,7 @@ variable "aurora_iops" {
 variable "additional_ingress_rules_rds" {
   description = "Additional ingress rules for RDS"
   type = list(object({
+    name        = string
     description = string
     type        = string
     from_port   = number


### PR DESCRIPTION
## Description

Currently, the ARC DB module only accepts a new security group ID and does not provide a way to add additional ingress or egress rules. Update the variable with required parameters

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

