### PR TITLE
86-remove-the-tf-version-constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ To see a full example, check out the [main.tf](https://github.com/sourcefuse/ter
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3, < 2.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.1.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4 |
 
 ## Providers
 
@@ -38,9 +38,9 @@ To see a full example, check out the [main.tf](https://github.com/sourcefuse/ter
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora_cluster"></a> [aurora\_cluster](#module\_aurora\_cluster) | git::https://github.com/cloudposse/terraform-aws-rds-cluster.git | 1.9.0 |
-| <a name="module_db_management"></a> [db\_management](#module\_db\_management) | git::https://github.com/cloudposse/terraform-aws-s3-bucket | 4.2.0 |
-| <a name="module_rds_instance"></a> [rds\_instance](#module\_rds\_instance) | git::https://github.com/cloudposse/terraform-aws-rds | 1.1.1 |
+| <a name="module_aurora_cluster"></a> [aurora\_cluster](#module\_aurora\_cluster) | git::https://github.com/cloudposse/terraform-aws-rds-cluster.git | 1.11.0 |
+| <a name="module_db_management"></a> [db\_management](#module\_db\_management) | git::https://github.com/cloudposse/terraform-aws-s3-bucket | 4.5.0 |
+| <a name="module_rds_instance"></a> [rds\_instance](#module\_rds\_instance) | git::https://github.com/cloudposse/terraform-aws-rds | 1.1.2 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "random_password" "rds_db_admin_password" {
 ## aurora cluster
 ################################################################################
 module "aurora_cluster" {
-  source = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=1.9.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=1.11.0"
   count  = var.aurora_cluster_enabled == true ? 1 : 0
 
   name = local.aurora_cluster_name
@@ -210,7 +210,7 @@ resource "aws_security_group_rule" "additional_ingress_rules_aurora" {
 ## s3 db management
 ################################################################################
 module "db_management" {
-  source = "git::https://github.com/cloudposse/terraform-aws-s3-bucket?ref=4.2.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-s3-bucket?ref=4.5.0"
   count  = var.rds_enable_custom_option_group == true ? 1 : 0
 
   name = "${local.rds_instance_name}-db-management"
@@ -366,7 +366,7 @@ resource "aws_db_instance_role_association" "this" {
 ################################################################################
 module "rds_instance" {
   count  = var.rds_instance_enabled == true ? 1 : 0
-  source = "git::https://github.com/cloudposse/terraform-aws-rds?ref=1.1.1"
+  source = "git::https://github.com/cloudposse/terraform-aws-rds?ref=1.1.2"
 
   name = local.rds_instance_name
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.3, < 2.0.0"
+  required_version = ">= 1.3, < 2.0.0"
 
   required_providers {
     aws = {
@@ -9,11 +9,11 @@ terraform {
 
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.1.1"
+      version = ">= 3.1"
     }
 
     random = {
-      version = ">= 3.4.0"
+      version = ">= 3.4"
       source  = "hashicorp/random"
     }
   }


### PR DESCRIPTION
Upgraded module sources for Aurora, S3, and RDS instances to their latest versions. Adjusted Terraform and provider version constraints in `versions.tf` and `README.md` for better compatibility.

closes #86 